### PR TITLE
R# warns clearance

### DIFF
--- a/src/content/src/Tests/WebAPIService.Integration.Tests/ValuesControllerTests.cs
+++ b/src/content/src/Tests/WebAPIService.Integration.Tests/ValuesControllerTests.cs
@@ -7,7 +7,8 @@ using Xunit;
 // ReSharper disable once CheckNamespace
 public class ValuesControllerTests
 {
-    private Xunit.Abstractions.ITestOutputHelper Console;
+    // ReSharper disable once InconsistentNaming
+    private readonly Xunit.Abstractions.ITestOutputHelper Console;
 
     public ValuesControllerTests(Xunit.Abstractions.ITestOutputHelper console)
     {


### PR DESCRIPTION
Resharper warns this could be made readonly and name convention violation (which I get, to keep Console same as the static built-in type) so added the exception comment.