### PR TITLE
Add ConfigureContainer to Startup

### DIFF
--- a/src/content/src/WebAPIService/Program.cs
+++ b/src/content/src/WebAPIService/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Threading;
+using Autofac.Extensions.DependencyInjection;
 using Eshopworld.Telemetry;
 using Eshopworld.Web;
 using Microsoft.AspNetCore.Hosting;
@@ -36,6 +37,7 @@ namespace WebAPIService
                 else
                 {
                     var host = WebHost.CreateDefaultBuilder()
+                        .ConfigureServices(services => services.AddAutofac())
                         .UseStartup<Startup>()
                         .Build();
 

--- a/src/content/src/WebAPIService/Startup.cs
+++ b/src/content/src/WebAPIService/Startup.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using Autofac;
-using Autofac.Extensions.DependencyInjection;
 using Eshopworld.Core;
 using Eshopworld.DevOps;
 using Eshopworld.Web;
@@ -46,7 +45,7 @@ namespace WebAPIService
         /// </summary>
         /// <param name="services">service collection</param>
         /// <returns>service provider instance (Autofac provider)</returns>
-        public IServiceProvider ConfigureServices(IServiceCollection services)
+        public void ConfigureServices(IServiceCollection services)
         {
             try
             {
@@ -118,15 +117,6 @@ namespace WebAPIService
                         //TODO: this requires Eshopworld.Beatles.Security to be refactored
                         //x.AddJwtBearerEventsTelemetry(bb); 
                     });
-
-                var builder = new ContainerBuilder();
-                builder.Populate(services);
-                builder.RegisterInstance(_bb).As<IBigBrother>().SingleInstance();
-
-                // add additional services or modules into container here
-
-                var container = builder.Build();
-                return new AutofacServiceProvider(container);
             }
             catch (Exception e)
             {
@@ -157,6 +147,17 @@ namespace WebAPIService
             app.UseAuthentication();
 
             app.UseMvc();
+        }
+
+        /// <summary>
+        /// Register services directly with Autofac. This runs after ConfigureServices
+        /// so the services here will override registrations made in ConfigureServices (useful for testing).
+        /// Don't build the container; that gets done for you.
+        /// </summary>
+        /// <param name="builder">Container Builder</param>
+        public void ConfigureContainer(ContainerBuilder builder)
+        {
+            builder.RegisterInstance(_bb).As<IBigBrother>().SingleInstance();
         }
     }
 }

--- a/src/content/src/WebAPIService/WebAPIService.cs
+++ b/src/content/src/WebAPIService/WebAPIService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Fabric;
 using System.IO;
+using Autofac.Extensions.DependencyInjection;
 using Eshopworld.Web;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.ServiceFabric;
@@ -39,6 +40,7 @@ namespace WebAPIService
                                     .UseKestrel()
                                     .ConfigureServices(
                                         services => services
+                                            .AddAutofac()
                                             .AddSingleton(serviceContext)
                                             .AddSingleton<ITelemetryInitializer>((serviceProvider) => FabricTelemetryInitializerExtension.CreateFabricTelemetryInitializer(serviceContext))
                                             .AddSingleton<ITelemetryModule>(new ServiceRemotingDependencyTrackingTelemetryModule())


### PR DESCRIPTION
Add ConfigureContainer method to Startup, this will be the default in ASP.NET Core 3. Enables better integration testing using Microsoft.AspNetCore.Mvc.Testing as mocked services can be registered using the **ConfigureTestServices** provided by the host builder.

[Autofac Documentation](https://autofaccn.readthedocs.io/en/latest/integration/aspnetcore.html)
[Injecting Mock Services](https://docs.microsoft.com/en-us/aspnet/core/test/integration-tests?view=aspnetcore-2.2#inject-mock-services)